### PR TITLE
Manifest id updated

### DIFF
--- a/Manifest/manifest_authors.json
+++ b/Manifest/manifest_authors.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.5/MicrosoftTeams.schema.json",
   "manifestVersion": "1.5",
   "version": "1.0.0",
-  "id": "1c07cd26-a088-4db8-8928-ace382fa219f",
+  "id": "0c7397fc-9062-4eed-a16b-d8da7c330b8a",
   "packageName": "com.microsoft.teams.diconnect.comms",
   "developer": {
     "name": "<<companyName>>",

--- a/Manifest/manifest_users.json
+++ b/Manifest/manifest_users.json
@@ -2,7 +2,7 @@
   "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.5/MicrosoftTeams.schema.json",
   "manifestVersion": "1.5",
   "version": "1.0.0",
-  "id": "148a66bb-e83d-425a-927d-09f4299a9274",
+  "id": "fe0dfdaa-f1f7-4d85-9fd1-35b4edf4ffd1",
   "packageName": "com.microsoft.teams.diconnect",
   "developer": {
     "name": "<<companyName>>",


### PR DESCRIPTION
[Fix] The manifest id of authors and users needs to be updated, as they are same as company communicator app template. Due to this tenants who already installed CC app template will get conflict. Updated the id of both users and authors manifest to resolve the issue.